### PR TITLE
Add Slalom Build capability to catalog

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,15 @@ capabilities = {
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    },
+    "Slalom Build": {
+        "description": "Product strategy, design thinking, and full-stack digital product development from concept to launch",
+        "practice_area": "Technology",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Certified Product Manager", "PMI-ACP", "SAFe Product Owner/Product Manager", "Google UX Design Certificate"],
+        "industry_verticals": ["Consumer Products", "Financial Services", "Healthcare", "Technology"],
+        "capacity": 40,
+        "consultants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing **Slalom Build** capability to the capabilities catalog, resolving the time-sensitive request from the Build practice team.

Closes #6

## Changes

- Added `"Slalom Build"` entry to the capabilities dictionary in `app.py` with:
  - **Description**: Product strategy, design thinking, and full-stack digital product development from concept to launch
  - **Practice Area**: Technology
  - **Skill Levels**: Emerging, Proficient, Advanced, Expert
  - **Certifications**: Certified Product Manager, PMI-ACP, SAFe PO/PM, Google UX Design Certificate
  - **Industry Verticals**: Consumer Products, Financial Services, Healthcare, Technology
  - **Capacity**: 40 hrs/week
  - **Consultants**: Empty list (ready for self-registration)

## Testing

Start the app and verify the Slalom Build capability appears in the UI and is selectable in the registration dropdown:

```shell
cd src && uvicorn app:app --reload
```